### PR TITLE
Make a clean clone work for someone who isn't you

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,22 @@ jobs:
         run: python -m pytest -q
 
   frontend:
-    name: Frontend
+    name: Frontend (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Both ends of the supported range from package.json engines. Pinning
+        # the low end matters: a bare '20' silently floats to whatever the
+        # runner ships, so the declared 20.19 floor would never actually be
+        # exercised.
+        node-version: ['20.19', '22']
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ The core signal is **VSR (views ÷ subscribers)**. In the demo run above, a 140k
 
 ## Quickstart
 
-Needs **Python 3.10+** and **Node 20+**. On macOS `python3` is still 3.9, so
+Needs **Python 3.10+** and **Node 20.19+ or 22.12+** (what Vite and oxlint
+require — plain "Node 20" is not enough, and 21.x will not work). On macOS `python3` is still 3.9, so
 `make install` picks the newest suitable interpreter on your PATH — point it
 somewhere specific with `make install PYTHON=/path/to/python3.12`.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,18 +2,18 @@
 
 ## Reporting a vulnerability
 
-**Please do not open a public issue for a security problem.**
+If you have found something that could put a user's API keys or machine at
+risk, **please report it without posting the details publicly.**
 
-Use GitHub's private reporting instead:
-[**Report a vulnerability**](https://github.com/shkuratovdesigner/yuben-app/security/advisories/new).
-That opens a private thread visible only to the maintainer.
+Open an issue titled "Security report" with no specifics — just say you have
+one and how to reach you — and you'll get a reply to continue privately.
 
-Useful things to include, if you have them: what an attacker can do, the steps
-to reproduce, and which version or commit you tested. A proof of concept is
-welcome but not required.
+Useful things to include once we're in touch: what an attacker can do, the
+steps to reproduce, and which version or commit you tested. A proof of concept
+is welcome but not required.
 
-Expect a first response within a week. If a fix is warranted, the advisory
-stays private until it ships, and you'll be credited unless you'd rather not be.
+Expect a first response within a week. You'll be credited when a fix ships,
+unless you'd rather not be.
 
 ## What this project's threat model actually is
 

--- a/frontend/fixtures
+++ b/frontend/fixtures
@@ -1,1 +1,0 @@
-../contracts/fixtures

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  },
   "scripts": {
     "dev": "vite",
     "dev:live": "VITE_USE_MOCKS=0 vite",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -39,12 +39,12 @@ import { API_BASE, USE_MOCKS } from '@/lib/env'
 
 // Bundled fixtures (mock data source). JSON imports need `resolveJsonModule`;
 // the JSONL stream is imported as raw text (`vite/client` types `?raw` = string).
-import adaptersJson from '../../fixtures/adapters.json'
-import configJson from '../../fixtures/config.json'
-import historyJson from '../../fixtures/history.json'
-import longformJson from '../../fixtures/research-result.longform.json'
-import shortsJson from '../../fixtures/research-result.shorts.json'
-import eventsRaw from '../../fixtures/progress-events.jsonl?raw'
+import adaptersJson from '@fixtures/adapters.json'
+import configJson from '@fixtures/config.json'
+import historyJson from '@fixtures/history.json'
+import longformJson from '@fixtures/research-result.longform.json'
+import shortsJson from '@fixtures/research-result.shorts.json'
+import eventsRaw from '@fixtures/progress-events.jsonl?raw'
 
 /**
  * The client every screen imports. One method per CONTRACTS §1 endpoint plus

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -11,7 +11,8 @@
 
     /* Path alias: @ -> src (TS 6 resolves paths relative to this file; no baseUrl) */
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@fixtures/*": ["../contracts/fixtures/*"]
     },
 
     /* Bundler mode */

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,6 +9,11 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(import.meta.dirname, './src'),
+      // The shared contract fixtures, one level up. This used to be a
+      // `frontend/fixtures` symlink, which git checks out as a 21-byte text
+      // file on Windows without core.symlinks — breaking `dev` and `build`
+      // outright. An alias resolves identically on every platform.
+      '@fixtures': path.resolve(import.meta.dirname, '../contracts/fixtures'),
     },
   },
   server: {

--- a/longform_research.py
+++ b/longform_research.py
@@ -23,9 +23,22 @@ import urllib.parse
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
-if _PROJECT_ROOT not in sys.path:
-    sys.path.insert(0, _PROJECT_ROOT)
+# Make `youtube_research.*` resolve to this directory when the script is run
+# directly (`python longform_research.py`). Under the backend this is already
+# done by app/pipeline/_paths.py, so both guards below are no-ops there.
+#
+# This block used to put the repo's *parent* on sys.path, which only resolved
+# through a `youtube_research -> YuBen` symlink that existed on one machine. On
+# a clean checkout the script died with ModuleNotFoundError.
+_REPO_ROOT = Path(__file__).resolve().parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+if "youtube_research" not in sys.modules:
+    import types as _types
+
+    _pkg = _types.ModuleType("youtube_research")
+    _pkg.__path__ = [str(_REPO_ROOT)]  # type: ignore[attr-defined]
+    sys.modules["youtube_research"] = _pkg
 
 from googleapiclient.errors import HttpError
 from youtube_research.youtube_api import (

--- a/shorts_research.py
+++ b/shorts_research.py
@@ -18,9 +18,22 @@ import statistics
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
-if _PROJECT_ROOT not in sys.path:
-    sys.path.insert(0, _PROJECT_ROOT)
+# Make `youtube_research.*` resolve to this directory when the script is run
+# directly (`python shorts_research.py`). Under the backend this is already done
+# by app/pipeline/_paths.py, so both guards below are no-ops there.
+#
+# This block used to put the repo's *parent* on sys.path, which only resolved
+# through a `youtube_research -> YuBen` symlink that existed on one machine. On
+# a clean checkout the script died with ModuleNotFoundError.
+_REPO_ROOT = Path(__file__).resolve().parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+if "youtube_research" not in sys.modules:
+    import types as _types
+
+    _pkg = _types.ModuleType("youtube_research")
+    _pkg.__path__ = [str(_REPO_ROOT)]  # type: ignore[attr-defined]
+    sys.modules["youtube_research"] = _pkg
 
 from googleapiclient.errors import HttpError
 from youtube_research.youtube_api import (


### PR DESCRIPTION
Three things in this repo worked only on the machine it was built on. None is a security issue — all three are "a stranger clones it and it doesn't run".

**The root scripts resolved through a symlink that exists on one Mac.** `longform_research.py` and `shorts_research.py` put the repo's *parent* on `sys.path` and imported `youtube_research.*`, which only resolved via a `youtube_research -> YuBen` symlink in that parent directory. Verified by cloning into a directory without it: before, both scripts die on import with `ModuleNotFoundError`; after, both load. They now register the same namespace shim `app/pipeline/_paths.py` installs, so the backend path is untouched and the guards are no-ops there.

**`frontend/fixtures` was a symlink, and Windows can't check it out.** Six `api.ts` imports traversed it. Without `core.symlinks`, git writes a 21-byte text file instead, so `npm run dev` and `npm run build` both fail at module resolution — for every Windows contributor, in live mode as well as mock. Replaced with a `@fixtures` alias plus a matching tsconfig path. Confirmed resolving in both serve and build modes, with the fixture data still inlined in the bundle.

**The README's Node floor was wrong.** It said "Node 20+"; Vite, oxlint and the React plugin all require `^20.19.0 || >=22.12.0`. Node 20.0–20.18, all of 21.x and 22.0–22.11 satisfied the README and broke the build, with no `engines` field to catch it. Added the field, corrected the text, and pinned CI's low end — a bare `'20'` floats to whatever the runner ships, so the declared floor was never actually exercised.

Also rewords `SECURITY.md`. It pointed at GitHub's private advisory form, which is disabled on this repo, so the single link a security reporter would follow went nowhere. It now describes a route that works without any repo setting.

## Verification

167 backend tests pass, fixtures validate, frontend lints and builds. The clean-clone failure was reproduced before the fix and confirmed gone after. The new `20.19` CI leg exercises the Node floor for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)